### PR TITLE
Copy binary to vendor/bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
 # PHP-Markdown-Documentation-Generator
 
-The documentation is just as important as the code it's refering to. With this command line tool 
+Documentation is just as important as the code it's refering to. With this command line tool 
 you will be able to write your documentation once, and only once! 
 
-Write your code documentation following the standard set by [phpdoc](http://www.phpdoc.org/) and generate a markdown-formatted
-documentation by calling `phpdocs-md` in your console.
+This project will write a single-page markdown-formatted API document based on the DocBlock comments in your source code. The [phpdoc](http://www.phpdoc.org/) standard is used.
 
 ![Travis](https://travis-ci.org/victorjonsson/PHP-Markdown-Documentation-Generator.svg)
 
 ### Example
 
-Let's say you have your PHP classes in a directory named "src". Each class has its own file named the same way as the class.
+Let's say you have your PHP classes in a directory named "src". Each class has its own file that is named after the class.
 
 ```
 - src/
@@ -18,7 +17,7 @@ Let's say you have your PHP classes in a directory named "src". Each class has i
   - OtherObject.php
 ```
 
-You write your code documentation following the standard set by [phpdoc](http://www.phpdoc.org/). 
+Write your code documentation following the standard set by [phpdoc](http://www.phpdoc.org/). 
 
 ```php
 namespace Acme;
@@ -40,51 +39,58 @@ class MyObject {
 }
 ```
 
-By then calling `$ phpdocs-md generate src > docs.md` in your console (the second argument being the path
-to your class directory) your class documentation will be written to docs.md.
+Then, running `$ phpdocs-md generate src > api.md` will write your API documentation to the file api.md.
 
-[Here you can see a rendered example](https://github.com/victorjonsson/PHP-Markdown-Documentation-Generator/blob/master/docs.md)
+[Here you can see a rendered example](https://github.com/victorjonsson/PHP-Markdown-Documentation-Generator/blob/master/api.md)
 
-Only public and protected functions will be a part of the documentation but you can also add `@ignore` to any function or class to exclude it from the docs. The program will try to guess the return type of functions that don't declare the return type. The program uses reflection to get as much information as possible out of the code so that functions that's missing doc comments will also be  included in the generated documentation.
+Only public and protected functions will be a part of the documentation, but you can also add `@ignore` to any function or class to exclude it from the docs. Phpdocs-md will try to guess the return type of functions that don't explicitly declare one. The program uses reflection to get as much information as possible out of the code so that functions that are missing DocBlock comments will still be included in the generated documentation.
 
 ### Requirements
 
 - PHP version >= 5.3.2
 - Reflection activated in php.ini
-- Each class in its own file with the file name being the same as the class name.
+- Each class in its own file with the file name being the same as the class name
+- composer.json file in your project
 
 ### Installation / Usage
 
-This command line tool can be installed using [composer](https://getcomposer.org/). Add `"victorjonsson/markdowndocs": "dev-master"` to composer.json and run install/update. Now you can choose to use `vendor/victorjonsson/markdowndocs/bin/phpdocs-md` directly as an executable or copy it to your project root by calling `$ cp vendor/victorjonsson/markdowndocs/bin/phpdocs-md phpdocs-md`
+This command line tool can be installed using [composer](https://getcomposer.org/).
+
+From the local working directory of the project that you would like to document, run:
+```
+$ composer require --dev victorjonsson/markdowndocs
+```
+This will add victorjonsson/markdowndocs to the `require-dev` section of your project's composer.json file.  The phpdocs-md executable will automatically be copied to your project's `vendor/bin` directory.
 
 ##### Generating docs
 
-To generate the documentation you use the command `generate`. The command line tool also needs to know whether you want to generate docs for a certain class or if it should search through a directory after class files.
+The `generate` command generates your project's API documentation file. The command line tool needs to know whether you want to generate docs for a certain class, or if it should process every class in a specified directory search path.
 
 ```
 # Generate docs for a certain class
-$ ./phpdocs-md generate Acme\\NS\\MyClass 
+$ ./vendor/bin/phpdocs-md generate Acme\\NS\\MyClass 
 
 # Generate docs for several classes (comma separated)
-$ ./phpdocs-md generate Acme\\NS\\MyClass,Acme\\OtherNS\\OtherClass 
+$ ./vendor/bin/phpdocs-md generate Acme\\NS\\MyClass,Acme\\OtherNS\\OtherClass 
 
 # Generate docs for all classes in a source directory
-$ ./phpdocs-md generate includes/src
+$ ./vendor/bin/phpdocs-md generate includes/src
 
-# Generate docs for all classes in a source directory and send output to the file docs.md
-$ ./phpdocs-md generate includes/src > docs.md
+# Generate docs for all classes in a source directory and send output to the file api.md
+$ ./vendor/bin/phpdocs-md generate includes/src > api.md
 ```
 
-*Note that the classes has to be possible to load using the autoloader provided by composer.*
+* Note that any class to be documented must be loadable using the autoloader provided by composer. *
 
 ##### Bootstrapping
 
-Maybe your not using the autloader provided by composer or maybe there is something else that needs to be done before your classes can be instantiated. In that case you can tell the command line tool to load a php-file before generating the docs
+If you are not using the composer autoloader, or if there is something else that needs to be done before your classes can be instantiated, then you may request phpdocs-md to load a php bootstrap file prior to generating the docs
 
-`$ ./phpdocs-md generate --bootstrap=includes/init.php includes/src > docs.md`
+`$ ./vendor/bin/phpdocs-md generate --bootstrap=includes/init.php includes/src > api.md`
 
 ##### Excluding directories
 
-You can tell the command line tool to ignore certain directories in your class path by using the ignore-option.
+You can tell the command line tool to ignore certain directories in your class path by using the `--ignore` option.
 
-`$ ./phpdocs-md generate --ignore=test,examples includes/src > docs.md`
+`$ ./phpdocs-md generate --ignore=test,examples includes/src > api.md`
+

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ Only public and protected functions will be a part of the documentation, but you
 ### Requirements
 
 - PHP version >= 5.3.2
-- Reflection activated in php.ini
-- Each class in its own file with the file name being the same as the class name
-- composer.json file in your project
+- Reflection must be enabled in php.ini
+- Each class must be defined in its own file with the file name being the same as the class name
+- The project should use [Composer](https://getcomposer.org/)
 
 ### Installation / Usage
 

--- a/bin/phpdoc-md
+++ b/bin/phpdoc-md
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-$autoLoadPaths = array(__DIR__.'/vendor/autoload.php', __DIR__.'/../vendor/autoload.php', getcwd().'/vendor/autoload.php');
+$autoLoadPaths = array(__DIR__.'/vendor/autoload.php', __DIR__.'/../vendor/autoload.php', __DIR__.'/../../../autoload.php');
 foreach($autoLoadPaths as $autoloader) {
     if( file_exists($autoloader) ) {
         require $autoloader;

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "require-dev" : {
         "phpunit/phpunit": "3.7.23"
     },
+    "bin":["bin/phpdoc-md"],
     "autoload": {
         "psr-0": {"PHPDocsMD": "src/"}
     },

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,5 @@
     "bin":["bin/phpdoc-md"],
     "autoload": {
         "psr-0": {"PHPDocsMD": "src/"}
-    },
-    "scripts": {
-        "post-install-cmd": [
-            "\\PHPDocsMD\\Console\\CLI::install"
-        ]
     }
 }

--- a/src/PHPDocsMD/Console/CLI.php
+++ b/src/PHPDocsMD/Console/CLI.php
@@ -28,16 +28,4 @@ class CLI extends Application {
         $this->add(new PHPDocsMDCommand());
         return parent::run($input, $output);
     }
-
-    /**
-     * Moves a copy of phpdoc-md to project root
-     * @ignore
-     */
-    public static function install()
-    {
-        $phpdocExec = __DIR__.'/../../../bin/phpdoc-md';
-        $projExec = getcwd().'/phpdoc-md';
-        copy($phpdocExec, $projExec);
-        chmod($projExec, 0755);
-    }
 }


### PR DESCRIPTION
This PR adds `"bin":["bin/phpdoc-md"],` to the composer.json file, so that Composer will copy the phpdoc-md binary to the vendor-bin directory during installation, per standard conventions for Composer.

This change is complimented by a few more adjustments in line with this change:
- The autoload path now includes a path relative from **DIR** to the autoloader when this tool is stored in the vendor directory of some other project
- The post-install script that copies the executable is removed, since this is not necessary
- The documentation has been updated to describe the installation and usage instructions
