### PR TITLE
Add support for @see in markdown generation

### DIFF
--- a/src/PHPDocsMD/ClassEntity.php
+++ b/src/PHPDocsMD/ClassEntity.php
@@ -39,6 +39,11 @@ class ClassEntity extends CodeEntity {
     private $interfaces = [];
 
     /**
+     * @var array
+     */
+    private $see = [];
+
+    /**
      * @var bool
      */
     private $isNative;
@@ -120,6 +125,17 @@ class ClassEntity extends CodeEntity {
     }
 
     /**
+     * @param array $see
+     */
+    public function setSee(array $see)
+    {
+        $this->see = [];
+        foreach($see as $i) {
+            $this->see[] = $i;
+        }
+    }
+
+    /**
      * @param array $implements
      */
     public function setInterfaces(array $implements)
@@ -136,6 +152,14 @@ class ClassEntity extends CodeEntity {
     public function getInterfaces()
     {
         return $this->interfaces;
+    }
+
+    /**
+     * @return array
+     */
+    public function getSee()
+    {
+        return $this->see;
     }
 
     /**

--- a/src/PHPDocsMD/Console/PHPDocsMDCommand.php
+++ b/src/PHPDocsMD/Console/PHPDocsMDCommand.php
@@ -20,6 +20,7 @@ class PHPDocsMDCommand extends \Symfony\Component\Console\Command\Command {
     const ARG_CLASS = 'class';
     const OPT_BOOTSTRAP = 'bootstrap';
     const OPT_IGNORE = 'ignore';
+    const OPT_SEE = 'see';
 
     /**
      * @var array
@@ -60,6 +61,12 @@ class PHPDocsMDCommand extends \Symfony\Component\Console\Command\Command {
                 InputOption::VALUE_REQUIRED,
                 'Directories to ignore',
                 ''
+            )
+            ->addOption(
+                self::OPT_SEE,
+                null,
+                InputOption::VALUE_NONE,
+                'Include @see in generated markdown'
             );
     }
 
@@ -75,6 +82,7 @@ class PHPDocsMDCommand extends \Symfony\Component\Console\Command\Command {
         $classes = $input->getArgument(self::ARG_CLASS);
         $bootstrap = $input->getOption(self::OPT_BOOTSTRAP);
         $ignore = explode(',', $input->getOption(self::OPT_IGNORE));
+        $includeSee = $input->getOption(self::OPT_SEE);
         $requestingOneClass = false;
 
         if( $bootstrap ) {
@@ -130,7 +138,7 @@ class PHPDocsMDCommand extends \Symfony\Component\Console\Command\Command {
                                 '.php';
                         }
                     }
-                    $tableGenerator->addFunc($func);
+                    $tableGenerator->addFunc($func, $includeSee);
                 }
 
                 $docs = ($requestingOneClass ? '':'<hr /><a id="' . trim($classLinks[$class->getName()], '#') . '"></a>'.PHP_EOL);
@@ -143,6 +151,13 @@ class PHPDocsMDCommand extends \Symfony\Component\Console\Command\Command {
                     $docs .= '### '.$class->generateTitle().PHP_EOL.PHP_EOL;
                     if( $class->getDescription() )
                         $docs .= '> '.$class->getDescription().PHP_EOL.PHP_EOL;
+                }
+
+                if ($includeSee && $seeArray = $class->getSee()) {
+                    foreach ($seeArray as $see) {
+                        $docs .= 'See ' . $see . '<br />' . PHP_EOL;
+                    }
+                    $docs .= PHP_EOL;
                 }
 
                 if( $example = $class->getExample() ) {

--- a/src/PHPDocsMD/DocInfo.php
+++ b/src/PHPDocsMD/DocInfo.php
@@ -25,7 +25,8 @@ class DocInfo
             'params' => [],
             'description' => '',
             'example' => false,
-            'deprecated' => false
+            'deprecated' => false,
+            'see' => []
         ], $data);
     }
 
@@ -79,6 +80,14 @@ class DocInfo
     public function getDeprecationMessage()
     {
         return $this->data['deprecated'];
+    }
+
+    /**
+     * @return array
+     */
+    public function getSee()
+    {
+        return $this->data['see'];
     }
 
     /**

--- a/src/PHPDocsMD/DocInfoExtractor.php
+++ b/src/PHPDocsMD/DocInfoExtractor.php
@@ -28,6 +28,7 @@ class DocInfoExtractor
         $code->setName($reflection->getName());
         $code->setDescription($docInfo->getDescription());
         $code->setExample($docInfo->getExample());
+        $code->setSee($docInfo->getSee());
 
         if ($docInfo->getDeprecationMessage()) {
             $code->isDeprecated(true);
@@ -76,6 +77,9 @@ class DocInfoExtractor
                     list($name, $data) = $paramData;
                     $tags['params'][$name] = $data;
                 }
+            }
+            elseif( $words[0] == '@see' ) {
+                $tags['see'][] = $this->figureOutSeeDeclaration($words);
             }
             else {
                 // Start new tag
@@ -170,5 +174,26 @@ class DocInfoExtractor
         }
 
         return false;
+    }
+
+    /**
+     * @param $words
+     * @return array|false
+     */
+    private function figureOutSeeDeclaration($words)
+    {
+        array_shift($words);
+
+        if (!$words) {
+            return false;
+        } elseif (preg_match('#^http://|^https://#', $words[0])) {
+            $see = count($words) > 1
+                ? '[' . implode(' ', array_slice($words, 1)) . '](' . $words[0] . ')'
+                : '<' . $words[0] . '>';
+        } else {
+            $see = implode(' ', $words);
+        }
+
+        return $see;
     }
 }

--- a/src/PHPDocsMD/DocInfoExtractor.php
+++ b/src/PHPDocsMD/DocInfoExtractor.php
@@ -185,7 +185,7 @@ class DocInfoExtractor
         array_shift($words);
 
         if (!$words) {
-            return false;
+            $see = false;
         } elseif (preg_match('#^http://|^https://#', $words[0])) {
             $see = count($words) > 1
                 ? '[' . implode(' ', array_slice($words, 1)) . '](' . $words[0] . ')'

--- a/src/PHPDocsMD/FunctionEntity.php
+++ b/src/PHPDocsMD/FunctionEntity.php
@@ -39,6 +39,11 @@ class FunctionEntity extends CodeEntity {
     private $class = '';
 
     /**
+     * @var array
+     */
+    private $see = [];
+
+    /**
      * @var bool
      */
     private $isReturningNativeClass = false;
@@ -149,6 +154,22 @@ class FunctionEntity extends CodeEntity {
     public function getClass()
     {
         return $this->class;
+    }
+
+    /**
+     * @param array $see
+     */
+    public function setSee(array $see)
+    {
+        $this->see = $see;
+    }
+
+    /**
+     * @return array
+     */
+    public function getSee()
+    {
+        return $this->see;
     }
 }
 

--- a/src/PHPDocsMD/MDTableGenerator.php
+++ b/src/PHPDocsMD/MDTableGenerator.php
@@ -99,9 +99,10 @@ class MDTableGenerator {
      * row to the table and returns the markdown formatted string.
      *
      * @param FunctionEntity $func
+     * @param bool $see
      * @return string
      */
-    function addFunc(FunctionEntity $func)
+    function addFunc(FunctionEntity $func, $includeSee=false)
     {
         $this->fullClassName = $func->getClass();
 
@@ -134,6 +135,10 @@ class MDTableGenerator {
             $str .= '<br /><em>DEPRECATED - '.$func->getDeprecationMessage().'</em>';
         } elseif( $func->getDescription() ) {
             $str .= '<br /><em>'.$func->getDescription().'</em>';
+        }
+        if ($func->getSee() && $includeSee) {
+            $str .= '<br /><em>&nbsp;&nbsp;&nbsp;&nbsp;See: ' .
+                implode(', ', $func->getSee()) . '</em>';
         }
 
         $str = str_replace(['</strong><strong>', '</strong></strong> '], ['','</strong>'], trim($str));


### PR DESCRIPTION
Adds options `--see` to include `@see` tags in the generated markdown.