### PR TITLE
Support PHP8 + some minor dev updates

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/composer.lock export-ignore
+/tests export-ignore
+/phpunit.xml export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/vendor
+/composer.lock
+/.phpunit.result.cache
+/.idea

--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,15 @@
         "symfony/console": ">=2.6"
     },
     "require-dev" : {
-        "phpunit/phpunit": "3.7.23"
+        "phpunit/phpunit": "9.5"
     },
     "bin":["bin/phpdoc-md"],
     "autoload": {
         "psr-0": {"PHPDocsMD": "src/"}
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Acme\\": "test"
+        }
     }
 }

--- a/src/PHPDocsMD/Reflector.php
+++ b/src/PHPDocsMD/Reflector.php
@@ -336,15 +336,7 @@ class Reflector implements ReflectorInterface
      */
     static function getParamType(\ReflectionParameter $refParam)
     {
-        $export = \ReflectionParameter::export([
-                $refParam->getDeclaringClass()->name,
-                $refParam->getDeclaringFunction()->name
-            ],
-            $refParam->name,
-            true
-        );
-
-        $export =  str_replace(' or NULL', '', $export);
+        $export =  str_replace(' or NULL', '', (string)$refParam);
 
         $type = preg_replace('/.*?([\w\\\]+)\s+\$'.current(explode('=', $refParam->name)).'.*/', '\\1', $export);
         if( strpos($type, 'Parameter ') !== false ) {

--- a/test/ExampleClass.php
+++ b/test/ExampleClass.php
@@ -7,7 +7,8 @@ namespace Acme;
  *
  * @package Acme
  */
-abstract class ExampleClass implements \Reflector {
+abstract class ExampleClass implements \Reflector
+{
 
     /**
      * Description of a*a
@@ -49,7 +50,7 @@ abstract class ExampleClass implements \Reflector {
 
     }
 
-    function funcD($arg, $arr=array(), ExampleInterface $depr=null, \stdClass $class) {
+    function funcD($arg, $arr=array(), ExampleInterface $depr=null, \stdClass $class = null) {
 
     }
 

--- a/test/MDTableGeneratorTest.php
+++ b/test/MDTableGeneratorTest.php
@@ -1,6 +1,9 @@
 <?php
 
-class MDTableGeneratorTest extends PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class MDTableGeneratorTest extends TestCase
+{
 
     function testDeprecatedFunc()
     {

--- a/test/ReflectorTest.php
+++ b/test/ReflectorTest.php
@@ -2,8 +2,10 @@
 
 use PHPDocsMD\FunctionEntity;
 use PHPDocsMD\Reflector;
+use PHPUnit\Framework\TestCase;
 
-class ReflectorTest extends PHPUnit_Framework_TestCase {
+class ReflectorTest extends TestCase
+{
 
     /**
      * @var \PHPDocsMD\Reflector
@@ -15,7 +17,7 @@ class ReflectorTest extends PHPUnit_Framework_TestCase {
      */
     private $class;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         require_once __DIR__ . '/ExampleClass.php';
         $this->reflector = new Reflector('Acme\\ExampleClass');

--- a/test/UseInspectorTest.php
+++ b/test/UseInspectorTest.php
@@ -1,6 +1,9 @@
 <?php
 
-class UseInspectorTest extends PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class UseInspectorTest extends TestCase
+{
 
     function testInspection()
     {
@@ -37,6 +40,4 @@ class UseInspectorTest extends PHPUnit_Framework_TestCase {
         $inspector = new \PHPDocsMD\UseInspector();
         $this->assertEquals($expected, $inspector->getUseStatementsInString($code));
     }
-
-
 }


### PR DESCRIPTION
`::export()` was removed in PHP8, casting to a string should do the same thing (tests pass!), however I had to bump PHPunit to the latest 9.5 and add the autoload-dev to get everything running properly.

The PHPUnit change makes PHP 7.3 the min for dev purposes, not sure if that is something you want? However: only PHP 7.3+ are currently supported versions so might be time to raise the min requirements.

I took the liberty of adding a gitignore and gitattributes too to prevent files getting added and checking out unneeded test files in the package lib.